### PR TITLE
Current assert_in_delta value doesn't actually check for truncation

### DIFF
--- a/test/iteration_zero_test.rb
+++ b/test/iteration_zero_test.rb
@@ -28,12 +28,12 @@ class IterationZeroTest < Minitest::Test
   def test_enrollment_basics
     e = Enrollment.new({:name => "ACADEMY 20", :kindergarten_participation => {2010 => 0.3915, 2011 => 0.35356, 2012 => 0.2677}})
     all_years = {2010 => 0.3915, 2011 => 0.35356, 2012 => 0.2677}
-    assert_in_delta 0.391, e.kindergarten_participation_in_year(2010), 0.005
-    assert_in_delta 0.267, e.kindergarten_participation_in_year(2012), 0.005
+    assert_in_delta 0.391, e.kindergarten_participation_in_year(2010), 0.0005
+    assert_in_delta 0.267, e.kindergarten_participation_in_year(2012), 0.0005
 
     truncated = all_years.map { |year, rate| [year, rate.to_s[0..4].to_f]}.to_h
     truncated.each do |k,v|
-      assert_in_delta v, e.kindergarten_participation_by_year[k], 0.005
+      assert_in_delta v, e.kindergarten_participation_by_year[k], 0.0005
     end
   end
 
@@ -49,6 +49,6 @@ class IterationZeroTest < Minitest::Test
     enrollment = er.find_by_name(name)
     assert_equal name, enrollment.name
     assert enrollment.is_a?(Enrollment)
-    assert_in_delta 0.144, enrollment.kindergarten_participation_in_year(2004), 0.005
+    assert_in_delta 0.144, enrollment.kindergarten_participation_in_year(2004), 0.0005
   end
 end


### PR DESCRIPTION
Given 
all_years = {2010 => 0.3915, 2011 => 0.35356, 2012 => 0.2677}
assert_in_delta 0.267, e.kindergarten_participation_in_year(2012), 0.005

Test actually checks for a value in the range of 0.262 to 0.272, thus not actually looking for truncation
Changing deltas one place value (delta of 0.0005) seems to be more correctly looking for truncation while allowing for computation variation by looking for a range of 0.2665 to 0.2675

Verified manually by changing my truncating method to just return the original input value and continued to pass all tests involving truncation.
